### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ and increase discoverability for solutions within an enterprise.
 - `Product Documentation`_
 
 .. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#beta-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-private-catalog.svg
    :target: https://pypi.org/project/google-cloud-private-catalog/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-private-catalog.svg
@@ -80,4 +80,4 @@ Next Steps
    APIs that we cover.
 
 .. _Private Catalog API Product documentation:  https://cloud.google.com/private-catalog/docs/
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.