### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudprivatecatalog",
     "name_pretty": "Private Catalog",
     "product_documentation": "https://cloud.google.com/private-catalog/",
-    "client_documentation": "https://googleapis.dev/python/cloudprivatecatalog/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudprivatecatalog/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ and increase discoverability for solutions within an enterprise.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-private-catalog.svg
    :target: https://pypi.org/project/google-cloud-private-catalog/
 .. _Private Catalog API: https://cloud.google.com/private-catalog/
-.. _Client Library Documentation: https://googleapis.dev/python/cloudprivatecatalog/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudprivatecatalog/latest
 .. _Product Documentation:  https://cloud.google.com/private-catalog/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.